### PR TITLE
feat(i18n): translate CLIParseError messages from Chinese to English

### DIFF
--- a/src/cli/CLIParser.ts
+++ b/src/cli/CLIParser.ts
@@ -282,7 +282,7 @@ export class CLIParser {
         default:
           // 检查是否是未知选项
           if (arg.startsWith('-')) {
-            throw new CLIParseError(`未知选项: ${arg}`);
+            throw new CLIParseError(`Unknown option: ${arg}`);
           }
           // 如果不是选项，可能是位置参数（查询内容）
           if (!options.prompt) {
@@ -367,7 +367,7 @@ claude-replica - Claude Code 智能代码助手命令行工具
    */
   private requireValue(args: string[], index: number, optionName: string): string {
     if (index + 1 >= args.length || args[index + 1].startsWith('-')) {
-      throw new CLIParseError(`选项 ${optionName} 需要一个值`);
+      throw new CLIParseError(`Option ${optionName} requires a value`);
     }
     return args[index + 1];
   }
@@ -388,7 +388,7 @@ claude-replica - Claude Code 智能代码助手命令行工具
   private parsePermissionMode(value: string): PermissionMode {
     if (!VALID_PERMISSION_MODES.includes(value as PermissionMode)) {
       throw new CLIParseError(
-        `无效的权限模式: ${value}。有效值: ${VALID_PERMISSION_MODES.join(', ')}`
+        `Invalid permission mode: ${value}. Valid values: ${VALID_PERMISSION_MODES.join(', ')}`
       );
     }
     return value as PermissionMode;
@@ -400,7 +400,7 @@ claude-replica - Claude Code 智能代码助手命令行工具
   private parseOutputFormat(value: string): OutputFormat {
     if (!VALID_OUTPUT_FORMATS.includes(value as OutputFormat)) {
       throw new CLIParseError(
-        `无效的输出格式: ${value}。有效值: ${VALID_OUTPUT_FORMATS.join(', ')}`
+        `Invalid output format: ${value}. Valid values: ${VALID_OUTPUT_FORMATS.join(', ')}`
       );
     }
     return value as OutputFormat;
@@ -414,7 +414,7 @@ claude-replica - Claude Code 智能代码助手命令行工具
     for (const source of sources) {
       if (!VALID_SETTING_SOURCES.includes(source)) {
         throw new CLIParseError(
-          `无效的配置源: ${source}。有效值: ${VALID_SETTING_SOURCES.join(', ')}`
+          `Invalid setting source: ${source}. Valid values: ${VALID_SETTING_SOURCES.join(', ')}`
         );
       }
     }
@@ -427,7 +427,7 @@ claude-replica - Claude Code 智能代码助手命令行工具
   private parseNumber(value: string, optionName: string): number {
     const num = parseFloat(value);
     if (isNaN(num)) {
-      throw new CLIParseError(`选项 ${optionName} 需要一个数字值，但收到: ${value}`);
+      throw new CLIParseError(`Option ${optionName} requires a numeric value, but received: ${value}`);
     }
     return num;
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1050,8 +1050,8 @@ ${
    */
   private handleError(error: unknown): number {
     if (error instanceof CLIParseError) {
-      console.error(`参数错误: ${error.message}`);
-      console.error('使用 --help 查看帮助信息');
+      console.error(`Argument error: ${error.message}`);
+      console.error('Use --help for help information');
       return ExitCodes.CONFIG_ERROR;
     }
 


### PR DESCRIPTION
## Summary

This PR translates all CLIParseError exception messages from Chinese to English to improve internationalization and user experience.

## Changes

Modified 8 error messages across 2 files:

### src/cli/CLIParser.ts (6 messages)
- `未知选项: ${arg}` → `Unknown option: ${arg}`
- `选项 ${optionName} 需要一个值` → `Option ${optionName} requires a value`
- `无效的权限模式: ${value}。有效值: ...` → `Invalid permission mode: ${value}. Valid values: ...`
- `无效的输出格式: ${value}。有效值: ...` → `Invalid output format: ${value}. Valid values: ...`
- `无效的配置源: ${source}。有效值: ...` → `Invalid setting source: ${source}. Valid values: ...`
- `选项 ${optionName} 需要一个数字值，但收到: ${value}` → `Option ${optionName} requires a numeric value, but received: ${value}`

### src/main.ts (2 messages)
- `参数错误: ${error.message}` → `Argument error: ${error.message}`
- `使用 --help 查看帮助信息` → `Use --help for help information`

## Impact

- ✅ No functional changes - only error message text modified
- ✅ No test impact - tests verify error types, not specific messages
- ✅ Improved user experience with standardized English error messages
- ✅ Better internationalization support

## Testing

All changes follow TypeScript syntax rules and maintain backward compatibility. Error handling logic remains unchanged.